### PR TITLE
Enable plugins in wing sail models

### DIFF
--- a/land_yacht_gazebo/models/wing_sail/model.sdf
+++ b/land_yacht_gazebo/models/wing_sail/model.sdf
@@ -20,8 +20,9 @@
     <pose>0 0 0.05 0 0 0</pose>
     <static>false</static>
 
-    <!-- Sail plugin -->
-    <!-- <plugin name="wing_sail_liftdrag" filename="libSailPlugin.so">
+    <!-- Plugins -->
+    <plugin name="gz::sim::systems::SailLiftDrag"
+        filename="asv_sim-sail_lift_drag-system">
         <a0>0.0</a0>
         <cla>6.2832</cla>
         <alpha_stall>0.1592</alpha_stall>
@@ -35,40 +36,7 @@
         <link_name>wing_sail_link</link_name>
         <radial_symmetry>true</radial_symmetry>
         <topic>lift_drag</topic>
-    </plugin> -->
-
-    <!-- Gazebo / ROS plugins -->
-
-    <!-- ground truth -->
-    <!-- <plugin name="gazebo_ros_f3d" filename="libgazebo_ros_f3d.so">
-        <robotNamespace>/</robotNamespace>
-        <bodyName>wing_sail_link</bodyName>
-        <topicName>/gazebo/f3d/wing_sail_link</topicName>
-        <frameName>world</frameName>
-        <updateRate>50</updateRate>
-    </plugin> -->
-
-    <!-- force torque sensor -->
-    <!-- <plugin name="gazebo_ros_ft_sensor" filename="libgazebo_ros_ft_sensor.so">
-        <robotNamespace>/</robotNamespace>
-        <jointName>wing_sail_joint</jointName>
-        <topicName>/gazebo/ft_sensor/wing_sail_joint</topicName>
-        <gaussianNoise>0</gaussianNoise>
-        <updateRate>50</updateRate>
-    </plugin> -->
-
-    <!-- Fix base to the world [optional]
-
-        This is disabled in favour of a high mass base_link as fixing
-        the model to the world results in jitters.
-
-        See Also: http://gazebosim.org/tutorials/?tut=ros_urdf#RigidlyFixingAModeltotheWorld
-    -->
-    <!-- <link name="world" />
-    <joint type="fixed" name="base_link_joint">
-        <parent>world</parent>
-        <child>base_link</child>
-    </joint> -->
+    </plugin>
 
     <!-- Base -->
     <link name="base_link">

--- a/land_yacht_gazebo/models/wing_sail/model.sdf
+++ b/land_yacht_gazebo/models/wing_sail/model.sdf
@@ -22,7 +22,7 @@
 
     <!-- Plugins -->
     <plugin name="gz::sim::systems::SailLiftDrag"
-        filename="asv_sim-sail_lift_drag-system">
+        filename="asv_sim2-sail-lift-drag-system">
         <a0>0.0</a0>
         <cla>6.2832</cla>
         <alpha_stall>0.1592</alpha_stall>

--- a/land_yacht_gazebo/models/wing_sail_with_elevator/model.sdf
+++ b/land_yacht_gazebo/models/wing_sail_with_elevator/model.sdf
@@ -22,7 +22,7 @@
 
     <!-- Plugins -->
     <plugin name="gz::sim::systems::SailLiftDrag"
-        filename="asv_sim-sail-lift-drag-system">
+        filename="asv_sim2-sail-lift-drag-system">
         <a0>0.0</a0>
         <cla>6.2832</cla>
         <alpha_stall>0.1592</alpha_stall>

--- a/land_yacht_gazebo/models/wing_sail_with_elevator/model.sdf
+++ b/land_yacht_gazebo/models/wing_sail_with_elevator/model.sdf
@@ -22,7 +22,7 @@
 
     <!-- Plugins -->
     <plugin name="gz::sim::systems::SailLiftDrag"
-        filename="asv_sim-sail_lift_drag-system">
+        filename="asv_sim-sail-lift-drag-system">
         <a0>0.0</a0>
         <cla>6.2832</cla>
         <alpha_stall>0.1592</alpha_stall>

--- a/land_yacht_gazebo/models/wing_sail_with_elevator/model.sdf
+++ b/land_yacht_gazebo/models/wing_sail_with_elevator/model.sdf
@@ -20,8 +20,9 @@
     <pose>0 0 0.05 0 0 0</pose>
     <static>false</static>
 
-    <!-- Sail plugin -->
-    <!-- <plugin name="wing_sail_liftdrag" filename="libSailPlugin.so">
+    <!-- Plugins -->
+    <plugin name="gz::sim::systems::SailLiftDrag"
+        filename="asv_sim-sail_lift_drag-system">
         <a0>0.0</a0>
         <cla>6.2832</cla>
         <alpha_stall>0.1592</alpha_stall>
@@ -35,36 +36,7 @@
         <link_name>wing_sail_link</link_name>
         <radial_symmetry>true</radial_symmetry>
         <topic>lift_drag</topic>
-    </plugin> -->
-
-    <!-- Gazebo / ROS plugins -->
-
-    <!-- joint states -->
-    <!-- <plugin name="gazebo_ros_joint_state_publisher" filename="libgazebo_ros_joint_state_publisher.so">
-        <robotNamespace>/</robotNamespace>
-        <jointName>
-            wing_sail_joint
-        </jointName>
-        <updateRate>50</updateRate>
-    </plugin> -->
-
-    <!-- ground truth -->
-    <!-- <plugin name="gazebo_ros_f3d" filename="libgazebo_ros_f3d.so">
-        <robotNamespace>/</robotNamespace>
-        <bodyName>wing_sail_link</bodyName>
-        <topicName>/gazebo/f3d/wing_sail_link</topicName>
-        <frameName>world</frameName>
-        <updateRate>50</updateRate>
-    </plugin> -->
-
-    <!-- force torque sensor -->
-    <!-- <plugin name="gazebo_ros_ft_sensor" filename="libgazebo_ros_ft_sensor.so">
-        <robotNamespace>/</robotNamespace>
-        <jointName>wing_sail_joint</jointName>
-        <topicName>/gazebo/ft_sensor/wing_sail_joint</topicName>
-        <gaussianNoise>0</gaussianNoise>
-        <updateRate>50</updateRate>
-    </plugin> -->
+    </plugin>
 
     <!-- Base -->
     <link name="base_link">
@@ -187,7 +159,7 @@
           <upper>1.0E16</upper>
         </limit>
         <dynamics>
-          <damping>0.01</damping>
+          <damping>0.1</damping>
         </dynamics>
       </axis>
       <sensor name="force_torque_sensor" type="force_torque">

--- a/land_yacht_gazebo/worlds/wingsail.sdf
+++ b/land_yacht_gazebo/worlds/wingsail.sdf
@@ -47,8 +47,59 @@
     </light>
 
     <wind>
-      <linear_velocity>-5.0 5.0 0.0</linear_velocity>
+      <linear_velocity>5.0 5.0 0.0</linear_velocity>
     </wind>
+
+    <model name="axes">
+      <static>1</static>
+      <link name="link">
+        <visual name="r">
+          <cast_shadows>0</cast_shadows>
+          <pose>5 0 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>10 0.01 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>1 0 0 1</ambient>
+            <diffuse>1 0 0 1</diffuse>
+            <emissive>1 0 0 1</emissive>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+        </visual>
+        <visual name="g">
+          <cast_shadows>0</cast_shadows>
+          <pose>0 5 0.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 10 0.01</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 1 0 1</ambient>
+            <diffuse>0 1 0 1</diffuse>
+            <emissive>0 1 0 1</emissive>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+        </visual>
+        <visual name="b">
+          <cast_shadows>0</cast_shadows>
+          <pose>0 0 5.1 0 0 0</pose>
+          <geometry>
+            <box>
+              <size>0.01 0.01 10</size>
+            </box>
+          </geometry>
+          <material>
+            <ambient>0 0 1 1</ambient>
+            <diffuse>0 0 1 1</diffuse>
+            <emissive>0 0 1 1</emissive>
+            <specular>0.5 0.5 0.5 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
 
     <model name="ground_plane">
       <static>true</static>
@@ -83,7 +134,7 @@
     </include>
 
     <include>
-        <pose>0 1.0 0.02 0 0 0</pose>
+        <pose>1 -1 0.02 0 0 0</pose>
         <uri>model://wing_sail_with_elevator</uri>
     </include>
 

--- a/land_yacht_gazebo/worlds/wingsail.sdf
+++ b/land_yacht_gazebo/worlds/wingsail.sdf
@@ -47,7 +47,7 @@
     </light>
 
     <wind>
-      <linear_velocity>5.0 5.0 0.0</linear_velocity>
+      <linear_velocity>2.0 2.0 0.0</linear_velocity>
     </wind>
 
     <model name="axes">

--- a/land_yacht_gazebo/worlds/wingsail.sdf
+++ b/land_yacht_gazebo/worlds/wingsail.sdf
@@ -47,7 +47,7 @@
     </light>
 
     <wind>
-      <linear_velocity>1.0 0.0 0.0</linear_velocity>
+      <linear_velocity>-5.0 5.0 0.0</linear_velocity>
     </wind>
 
     <model name="ground_plane">


### PR DESCRIPTION
- Enable the SailLiftDrag plugins in the two wing sail examples.
- Remove commented ROS plugins.
- Add axes for orientation to the wing sail world.
