### PR TITLE
Add Anemometer sensor and system

### DIFF
--- a/land_yacht_gazebo/models/land_yacht/model.sdf
+++ b/land_yacht_gazebo/models/land_yacht/model.sdf
@@ -103,37 +103,12 @@
         <visualize>1</visualize>
       </sensor>
 
-      <!-- <sensor name="camera" type="camera">
-        <always_on>1</always_on>
-        <update_rate>30</update_rate>
-        <camera name="camera">
-          <horizontal_fov>1.047</horizontal_fov>
-          <image>
-            <width>800</width>
-            <height>800</height>
-            <format>R8G8B8</format>
-          </image>
-          <clip>
-            <near>0.02</near>
-            <far>300</far>
-          </clip>
-        </camera>
-        <pose>0.5 0 0.3 0 0 0</pose>
-      </sensor> -->
-
-      <!-- <sensor name="anemometer_sensor" type="anemometer">
-        <pose>0 0 0 0 0 0</pose>
-        <always_on>true</always_on>
-        <update_rate>50</update_rate>
-        <topic>anemometer</topic>
-      </sensor>
-
       <visual name="anemometer_visual">
-        <pose>0 0 0 0 0 0</pose>
+        <pose>0.67 0 0.72 0 0 0</pose>
         <geometry>
           <cylinder>
-            <radius>0.025</radius>
-            <length>0.025</length>
+            <radius>0.034</radius>
+            <length>0.04</length>
           </cylinder>
         </geometry>
         <material>
@@ -141,16 +116,26 @@
           <diffuse>1.0 0.0 0.0 1.0</diffuse>
           <specular>0.1 0.1 0.1 1.0</specular>
         </material>
-      </visual> -->
+      </visual>
+
+      <sensor name="anemometer" type="custom" gz:type="anemometer">
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <topic>anemometer</topic>
+        <gz:anemometer>
+          <noise type="gaussian">
+            <mean>0.2</mean>
+            <stddev>0.1</stddev>
+          </noise>
+        </gz:anemometer>
+      </sensor>
 
       <!-- Approximate LY base inertial with a solid cuboid:
         m  = 3.544 kg
         Lx = 0.25 m
         Ly = 0.16 m
         Lz = 0.06 m
-
-        as most of the mass is located at the 
-        intersection of the two beams.
+        as most of the mass is located at the intersection of the two beams.
       -->
       <inertial>
         <pose>0.15 0 0.04 0 0 0</pose>

--- a/land_yacht_gazebo/worlds/land_yacht_beach.sdf
+++ b/land_yacht_gazebo/worlds/land_yacht_beach.sdf
@@ -35,6 +35,9 @@
     <plugin filename="gz-sim-imu-system"
         name="gz::sim::systems::Imu">
     </plugin>
+    <plugin filename="asv_sim2-anemometer-system"
+      name="gz::sim::systems::Anemometer">
+    </plugin>
 
     <scene>
       <ambient>1.0 1.0 1.0</ambient>

--- a/land_yacht_gazebo/worlds/sails_test.sdf
+++ b/land_yacht_gazebo/worlds/sails_test.sdf
@@ -37,6 +37,9 @@
     <plugin filename="gz-sim-imu-system"
         name="gz::sim::systems::Imu">
     </plugin>
+    <plugin filename="asv_sim2-anemometer-system"
+      name="gz::sim::systems::Anemometer">
+    </plugin>
 
     <scene>
       <ambient>1.0 1.0 1.0</ambient>


### PR DESCRIPTION
Add anemometer sensor and system to the land yacht model and worlds.

- Depends on https://github.com/srmainwaring/asv_sim/pull/13

## Test

The wind is set to:

```xml
<wind>
  <linear_velocity>-4 0 0</linear_velocity>
</wind>
```

Figure: land yacht with anemometer mounted on forward spar (red cylinder).

![land-yacht-anemometer](https://user-images.githubusercontent.com/24916364/224155478-712c05c9-ceee-4639-ae76-1ecf64786b9f.jpg)

When the land yacht is stationary the anemometer reads the apparent wind = true wind:

```bash
$ gz topic -e -t /anemometer -n 1
header {
  stamp {
    sec: 22
    nsec: 811000000
  }
  data {
    key: "frame_id"
    value: "land_yacht_with_ardupilot::land_yacht::base_link::anemometer"
  }
  data {
    key: "seq"
    value: "22810"
  }
}
x: -3.99999695854627
y: 3.3796566661453307e-11
z: -4.876706306623917e-09
```

